### PR TITLE
Dodo: compatibility with newer Draft v0.19

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -23,7 +23,13 @@
 #****************************************************************************
 
 class dodo ( Workbench ):
-  import DraftSnap
+  try:
+      import DraftSnap
+  except Exception:
+      import draftguitools.gui_snapper as DraftSnap
+  if not hasattr(FreeCADGui, "Snapper"):
+      FreeCADGui.Snapper = DraftSnap.Snapper()
+
   import sys, FreeCAD
   v=sys.version_info[0]
   if v<3: FreeCAD.Console.PrintWarning('Dodo is written for Py3 and Qt5\n You may experience mis-behaviuors\n')


### PR DESCRIPTION
The structure of the Draft workbench in FreeCAD is being updated so that it is easier to manage the large code base. Therefore, some modules have been shifted around.

The `DraftSnap` module was moved to `draftguitools/gui_snapper.py` in FreeCAD/FreeCAD#3091 (snapper).

Other pull requests that may affect the tools of Dodo are FreeCAD/FreeCAD#3092 (trackers), FreeCAD/FreeCAD#3094 (SelectPlane), FreeCAD/FreeCAD#3157 (WorkingPlane), 

Forum thread: [[Discussion] Splitting Draft tools into their own modules](https://forum.freecadweb.org/viewtopic.php?f=23&t=38593&start=40#p368890).