### PR TITLE
ChangeProfile  remove sketch profile

### DIFF
--- a/fFeatures.py
+++ b/fFeatures.py
@@ -511,7 +511,10 @@ class frameBranchForm(dodoDialogs.protoTypeDialog):
       name=FB.Profile.Name
       FB.Profile=profile
       FB.Proxy.redraw(FB)
-      FreeCAD.ActiveDocument.removeObject(name)
+      if self.SType == '<by sketch>':
+        profile.ViewObject.Visibility = False
+      else:
+        FreeCAD.ActiveDocument.removeObject(name)
       FreeCAD.ActiveDocument.recompute()
       FreeCAD.ActiveDocument.recompute()
     else:


### PR DESCRIPTION
Hello @oddtopus and thanks a lot for your interesting work.
When I ChangeProfile of FramBranch object, It removes sketch profile that I created. I think it is better to hide the profile.