### PR TITLE
[Dodo] Python 3.11.x and above Json Fix for FreeCAD 0.21.2 and above

### DIFF
--- a/fFeatures.py
+++ b/fFeatures.py
@@ -726,6 +726,10 @@ class ViewProviderFrameBranch:
     return None
   def __setstate__(self,state):
     return None
+  def dumps(self):
+    return None
+  def loads(self,state):
+    return None
   def claimChildren(self):
     children=[FreeCAD.ActiveDocument.getObject(name) for name in self.Object.Beams]
     return children 

--- a/pFeatures.py
+++ b/pFeatures.py
@@ -515,6 +515,10 @@ class ViewProviderPypeBranch:
     return None
   def __setstate__(self,state):
     return None
+  def dumps(self):
+    return None
+  def loads(self,state):
+    return None
   def claimChildren(self):
     children=[FreeCAD.ActiveDocument.getObject(name) for name in self.Object.Tubes+self.Object.Curves]
     return children

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
   <name>Dodo</name>
   <description>A set of commands and objects that help to speed-up the drawing of frames and pipelines. Py3/Qt5 port of flamingo.</description>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <maintainer email="unknown">Riccardo Treu (oddtopus)</maintainer>
   <license file="LICENSE">LGPLv3</license>
   <url type="repository" branch="master">https://github.com/oddtopus/dodo</url>


### PR DESCRIPTION
In order to fix errors using Python 3.11.x and above while preserving ability for Python 3.10.x and below to still work correctly, example error from another workbench:

```
  File "/usr/lib/python3.11/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
<class 'TypeError'>: Object of type FeaturePython is not JSON serializable
17:04:02  PropertyPythonObject::toString(): failed for <class 'SheetMetalCmd.SMViewProviderFlat'>
17:04:02  pyException: Traceback (most recent call last):
  File "/usr/lib/python3.11/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
```

Root Cause is https://github.com/FreeCAD/FreeCAD/commit/fbe2fef