### PR TITLE
Add Cut List Function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+cut_list/__pycache__/

--- a/InitGui.py
+++ b/InitGui.py
@@ -147,9 +147,29 @@ static char * dodo1_xpm[] = {
     self.utilsList=["selectSolids","queryModel","moveWorkPlane","offsetWorkPlane","rotateWorkPlane","hackedL","moveHandle","dpCalc"]
     self.appendToolbar("Utils",self.utilsList)
     Log ('Loading Utils: done\n')
+    
     import CFrame
-    self.frameList=["frameIt","FrameBranchManager","insertSection","spinSect","reverseBeam","shiftBeam","pivotBeam","levelBeam","alignEdge","rotJoin","alignFlange","stretchBeam","extend","adjustFrameAngle","insertPath"]
+    from cut_list.cut_list_commands import cutListCommand      
+ 
+    self.frameList=["frameIt",
+                    "FrameBranchManager",
+                    "insertSection",
+                    "spinSect",
+                    "reverseBeam",
+                    "shiftBeam",
+                    "pivotBeam",
+                    "levelBeam",
+                    "alignEdge",
+                    "rotJoin",
+                    "alignFlange",
+                    "stretchBeam",
+                    "extend",
+                    "adjustFrameAngle",
+                    "insertPath",
+                    "Create Cut List"]
+    
     self.appendToolbar("frameTools",self.frameList)
+    
     Log ('Loading Frame tools: done\n')
     import CPipe
     self.pypeList=["insertPipe","insertElbow","insertReduct","insertCap","insertValve","insertFlange","insertUbolt","insertPypeLine","insertBranch","insertTank","insertRoute","breakPipe","mateEdges","flat","extend2intersection","extend1intersection","makeHeader","laydown","raiseup","attach2tube","point2point","insertAnyz"]#,"joinPype"]

--- a/InitGui.py
+++ b/InitGui.py
@@ -166,7 +166,7 @@ static char * dodo1_xpm[] = {
                     "extend",
                     "adjustFrameAngle",
                     "insertPath",
-                    "Create Cut List"]
+                    "createCutList"]
     
     self.appendToolbar("frameTools",self.frameList)
     

--- a/cut_list/README.md
+++ b/cut_list/README.md
@@ -1,0 +1,64 @@
+# Cut List Creation Command for Freecad Dodo Workbench (Macro Version)
+
+This macro can be used to create a cut list of beams created by the DODO-Workbench.\
+The cut list can use one or more profiles (sections/sketches).\
+A position number will be generated for each profile & length combination (rounded to 0.01mm).\
+The script will create a new speadsheet object with each cut list.
+
+# How to use it
+[Cut_List.webm](https://github.com/FilePhil/dodo_Cutlist_Macro_Version/assets/16101101/e992a925-0a02-4560-8e7c-a22eef86234d)
+
+# Options
+## Group Parts by Size
+The Option "Group Parts by Size" will count all Pieces with the same profile and Length (rounded to 0.01mm).
+
+### Example: Group Party by Size
+
+| Beam No. 1 | | | |
+|-----------------------------|--|--|--|
+| Used 2855.0 mm | | | |		
+| Pos. | Profil | Length | Quantity |
+| 1 | 10X10 | 610,00 mm | 2 |
+| 2 | 10X10 | 600,00 mm | 2 |
+| 3 | 10X10 | 410,00 mm | 1 |
+
+### Exampl: Without Group Party by Size
+
+ | Beam No. 1 | | | |	
+ |-----------------------------|--|--|--|
+ | Used 2410.0 mm  | | | |			
+ | Pos.	 | Profil	 | Label	 | Length
+ | 1	 | 10X10	 | Structure006	 | 610,00 mm |
+ | 1	 | 10X10	 | Structure017	 | 610,00 mm |
+ | 2	 | 10X10	 | Structure012	 | 600,00 mm |
+ | 2	 | 10X10	 | Structure018	 | 600,00 mm |
+
+
+## Use Nesting
+The Option "Use Nesting" allows to specify the maximum length of the Stock Material and allows for optimizing of the available material.\
+The cut Width will be added to each piece to account for the saw thickness.\
+The list will be seperated into Sections and shows the Used Length and the Parts that can be cut from the Stock Material.\
+The position number of a piece will be the same on every stock material beam.
+
+### Example with Nesting & Group Party by Size
+
+| Beam No. 1 | | | |
+|-----------------------------|--|--|--|
+| Used 2855.0 mm of 3000.0 mm  | | | |
+| Pos. | Profil | Length | Quantity |
+| 1 | 10X10 | 610,00 mm | 2 |
+| 2 | 10X10 | 600,00 mm | 2 |
+| 3 | 10X10 | 410,00 mm | 1 |
+| | | | |
+| Beam No. 2   |
+| Used 3000.0 mm of 3000.0 mm   |
+| Pos. | Profil | Length | Quantity|
+| 3 | 10X10 | 410,00 mm | 1|
+| 4 | 10X10 | 390,00 mm | 2|
+| 5 | 10X10 | 210,00 mm | 2|
+| 6 | 10X10 | 190,00 mm | 7|
+| | | | |
+| Beam No. 3   |
+| Used 1365.0 mm of 3000.0 mm   |
+| Pos. | Profil | Length | Quantity|
+| 6 | 10X10 | 190,00 mm | 7|

--- a/cut_list/README.md
+++ b/cut_list/README.md
@@ -1,6 +1,6 @@
-# Cut List Creation Command for Freecad Dodo Workbench (Macro Version)
+# Cut List Creation Command for Dodo Workbench 
 
-This macro can be used to create a cut list of beams created by the DODO-Workbench.\
+This Module can be used to create a cut list of beams created by the DODO-Workbench.\
 The cut list can use one or more profiles (sections/sketches).\
 A position number will be generated for each profile & length combination (rounded to 0.01mm).\
 The script will create a new speadsheet object with each cut list.

--- a/cut_list/__init__.py
+++ b/cut_list/__init__.py
@@ -1,0 +1,29 @@
+#****************************************************************************
+#*                                                                          *
+#*   Cut List Creation for Dodo Workbench                                   *
+#*                                                                          *
+#*   Copyright (c) 2023 FilePhil LGPL                                       *
+#*                                                                          *
+#*   This program is free software; you can redistribute it and/or modify   *
+#*   it under the terms of the GNU Lesser General Public License (LGPL)     *
+#*   as published by the Free Software Foundation; either version 2 of      *
+#*   the License, or (at your option) any later version.                    *
+#*   for detail see the LICENCE text file.                                  *
+#*                                                                          *
+#*   This program is distributed in the hope that it will be useful,        *
+#*   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+#*   GNU Library General Public License for more details.                   *
+#*                                                                          *
+#*   You should have received a copy of the GNU Library General Public      *
+#*   License along with this program; if not, write to the Free Software    *
+#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307   *
+#*   USA                                                                    *
+#*                                                                          *
+#****************************************************************************
+
+
+import os
+
+RESOURCE_PATH = os.path.join(os.path.dirname(__file__), "resources")
+

--- a/cut_list/cut_list_commands.py
+++ b/cut_list/cut_list_commands.py
@@ -1,0 +1,30 @@
+import FreeCAD
+import FreeCADGui
+import os
+from . import cut_list_ui
+from . import cut_list_creation
+from . import RESOURCE_PATH
+
+
+class cutListCommand:
+    toolbarName = 'Cut List'
+    commandName = 'Create Cut List'
+
+    def GetResources(self):
+        Icon = os.path.join(RESOURCE_PATH, "cut_list_icon.svg")
+        return {'MenuText': self.commandName,
+                'ToolTip': "Create a new Cut List from Dodo Beams",
+                'Pixmap': Icon
+                }
+
+    def Activated(self):
+
+        cut_list_ui.openCutListDialog()
+
+    def IsActive(self):
+        """If there is no active document we can't do anything."""
+        return not FreeCAD.ActiveDocument is None
+
+
+
+FreeCADGui.addCommand(cutListCommand.commandName, cutListCommand())

--- a/cut_list/cut_list_commands.py
+++ b/cut_list/cut_list_commands.py
@@ -8,7 +8,7 @@ from . import RESOURCE_PATH
 
 class cutListCommand:
     toolbarName = 'Cut List'
-    commandName = 'Create Cut List'
+    commandName = 'createCutList'
 
     def GetResources(self):
         Icon = os.path.join(RESOURCE_PATH, "cut_list_icon.svg")

--- a/cut_list/cut_list_creation.py
+++ b/cut_list/cut_list_creation.py
@@ -1,0 +1,219 @@
+import FreeCAD
+import FreeCADGui
+
+from dataclasses import dataclass, asdict
+
+from . import resultSpreadsheet
+
+
+@dataclass
+class Cut:
+    """ Store the Infomation about the cutted Piece and provide Helper Functions
+    """
+    label: str
+    profil: str
+    length: object
+    cutwidth: object
+    position: int = 0
+
+    def getKey(self):
+        """ Provide a Key to generate the Position Number
+        """
+        return self.profil + "|" + str(round(self.length.getValueAs("mm"),2))
+    
+    def totalLength(self):
+        return self.length + self.cutwidth
+
+    def getRow(self):
+        """Provide the Information from the Cutted Piece in the form of a dict"""
+        return {"Label": self.label,"Profil": self.profil, "Length": self.length,"CutWidth": self.cutwidth,"Pos.":self.position}
+
+@dataclass
+class Beam:
+    """ Store the Infomation about the Stock Material Beam and provide Helper Functions
+    """
+    number: int
+    length: object
+    lengthLeft: object
+    cuts: list[Cut]
+
+    def addCut(self,cut):
+        """ Try to fit the cutted piece on the Beam and provide a status if it fits
+        """
+        if self.length.getValueAs("mm") > 0.1 and self.lengthLeft < cut.totalLength():
+            # Cut is not Possible on this Beam 
+            # Ignore if Beam has no lenght
+            return False
+
+        self.cuts.append(cut)
+        self.lengthLeft -= cut.totalLength()
+        return True
+
+    def getCutsAsDict(self):
+        """ Get a easy to work with Dict List of the Beams / Cuts"""
+        return [x.getRow() for x in self.cuts]
+    
+    def lengthUsed(self):
+        return self.length - self.lengthLeft
+
+
+def queryStructures(profiles:list,rootObjs = None):
+    """ Find all Structure Elements that use one of the selected profiles
+    """
+    
+    resultObjs = []
+
+    if rootObjs is None:
+        rootObjs = FreeCAD.ActiveDocument.Objects
+
+    for obj in rootObjs:   
+        # Follow Link Groups
+        if obj.TypeId == "App::LinkGroup":		
+            resultObjs = resultObjs + queryStructures(profiles,obj.ElementList)
+
+        # TODO: A Link to a ink Group will currently not be queried    
+        
+        # Get the base Profile Used for the Stucture
+        base = getattr(obj, "Base", None)
+        computedLength = getattr(obj, "ComputedLength", None)
+        
+        # Check if the Object is a valid Strucutre 
+        if base is None or computedLength is None:
+            continue
+
+        if base.Label in profiles:
+            resultObjs.append(obj)
+
+    return resultObjs
+
+def nestCuts(profiles:list,beamLength,cutwidth):
+    """ Nest a List of Cuts on a Standard Beam length to estimate the needed Beams.
+    """
+   
+    allStructures = queryStructures(profiles)
+
+    # Sort Cuts Big to Small
+    sortedStructures = sorted(allStructures, key=lambda x:x.ComputedLength, reverse=True)
+    
+    allCuts = [] 
+    beams = [] # List of Lists to reference what is together in one beam [beamLength,[Cut1,Cut2...]]
+    beam = Beam(1, beamLength, beamLength,[])
+    beams.append(beam)
+    
+    # Go through all Structure Objects and try to fit them onto the Beams
+    for obj in sortedStructures:
+
+        # Create Cut Object to hold all Attributes 
+        label =  obj.Label
+        profile = obj.Base.Label
+        length = round(obj.ComputedLength,2)
+        cutObj = Cut(label, profile, length, cutwidth)
+        
+        cutKey = cutObj.getKey()
+        
+        # Use the Key to define the Position Number of the Cut
+        if cutKey not in allCuts:
+            allCuts.append (cutKey)
+            cutObj.position = len(allCuts)
+        else:
+            cutObj.position = allCuts.index(cutKey)+1
+            
+        # Try to fit the Object on exsting Beam
+        nofit = True
+        for beam in beams:
+            if beam.addCut(cutObj):
+                nofit = False
+                break
+
+        # Add new Beam and add the Cut to it
+        if nofit:           
+            beam = Beam(len(beams)+1, beamLength,beamLength,[])
+            beams.append(beam)
+            if not beam.addCut(cutObj):
+                raise ValueError('Cut longer than beam!')
+
+    return beams
+
+
+def createSpreadSheetReport(beams, name="Result_Nest_Profile"):
+    """ Create a Spreadsheet as the Result of the Cut list Generation.
+        Each Piece will be displayed as One Row
+    """
+    result = FreeCAD.ActiveDocument.addObject("Spreadsheet::Sheet", name)
+
+    columnLabels = ["Pos.",'Profil','Label','Length']
+    result = resultSpreadsheet.ResultSpreadsheet(result, columnLabels)
+
+    for beam in beams:
+        result.printHeader(f"Beam No. {beam.number}")
+
+        # Print the Used Length if a maximum Stock Value is given
+        beamLength = round(beam.length,2)
+        if beamLength.getValueAs("mm") <= 0.1:
+            result.printHeader(f"Used {round(beam.lengthUsed(),2)}")
+        else:
+            result.printHeader(f"Used {round(beam.lengthUsed(),2)} of {beamLength}")
+
+        result.printColumnLabels()
+        result.printRows(beam.getCutsAsDict())
+        result.printEmptyLine()
+
+    result.recompute()
+
+def createSpreadSheetReportGrouped(beams, name="Result_Nest_Profile"):
+    """ Create a Spreadsheet as the Result of the Cut list Generation.
+        The Pieces will be grouped by the Length and Profile.
+    """
+
+    result = FreeCAD.ActiveDocument.addObject("Spreadsheet::Sheet", name)
+
+    columnLabels = ["Pos.","Profil","Length","Quantity"]
+    result = resultSpreadsheet.ResultSpreadsheet(result, columnLabels)
+
+    for beam in beams:
+        result.printHeader(f"Beam No. {beam.number}")
+
+        # Print the Used Length if a maximum Stock Value is given
+        beamLength = round(beam.length,2)
+        if beamLength.getValueAs("mm") <= 0.1:
+            result.printHeader(f"Used {round(beam.lengthUsed(),2)}")
+        else:
+            result.printHeader(f"Used {round(beam.lengthUsed(),2)} of {beamLength}")
+        
+        result.printColumnLabels()
+
+        resultRows = []
+        usedKeys = []
+
+        for cut in beam.cuts:
+            # Add only one Row for each Key on the Beam
+            currentCutKey = cut.getKey()
+            if currentCutKey not in usedKeys:
+
+                roWDict = cut.getRow()
+                # Calculate the Number of the same pieces
+                roWDict["Quantity"] = len([x for x in beam.cuts if x.getKey() == currentCutKey])
+                
+                resultRows.append(roWDict)
+                usedKeys.append(cut.getKey())
+
+        result.printRows(resultRows)
+        result.printEmptyLine()
+
+    result.recompute()
+
+
+def createCutlist(profiles,maxBeamLength,cutWidth,GroupByLength=False):
+    """ Nest the Cuts to the Beams and create the Report Spreadsheet
+    """
+
+    profilesLabel = "_".join(profiles)
+    tableName = f"Cut_List_{profilesLabel}"
+
+    beams = nestCuts(profiles,maxBeamLength,cutWidth)
+
+    if GroupByLength:
+        createSpreadSheetReportGrouped(beams,tableName)
+    else:
+        createSpreadSheetReport(beams,tableName)
+    

--- a/cut_list/cut_list_creation.py
+++ b/cut_list/cut_list_creation.py
@@ -2,6 +2,7 @@ import FreeCAD
 import FreeCADGui
 
 from dataclasses import dataclass, asdict
+from typing import List
 
 from . import resultSpreadsheet
 
@@ -35,7 +36,7 @@ class Beam:
     number: int
     length: object
     lengthLeft: object
-    cuts: list[Cut]
+    cuts: List[Cut]
 
     def addCut(self,cut):
         """ Try to fit the cutted piece on the Beam and provide a status if it fits

--- a/cut_list/cut_list_ui.py
+++ b/cut_list/cut_list_ui.py
@@ -1,0 +1,106 @@
+import FreeCAD,FreeCADGui,Part
+import os
+
+from FreeCAD import Units
+from PySide import QtCore
+
+from . import RESOURCE_PATH
+from . import cut_list_creation
+
+
+class cutListUI:
+    def __init__(self):
+        uiPath = os.path.join(RESOURCE_PATH, "cut_list_dialog.ui")
+        # this will create a Qt widget from our ui file
+        self.form = FreeCADGui.PySideUic.loadUi(uiPath)
+
+        # Set the Default Values and allow only Positiv Values
+        maxStockDefault = Units.parseQuantity("6m")
+        cutWidthDefault = Units.parseQuantity("5mm")
+
+        self.form.max_stock_length.setProperty("value",maxStockDefault)
+        self.form.max_stock_length.setProperty("minimum",0.0) 
+
+        self.form.cut_width.setProperty("value",cutWidthDefault)
+        self.form.cut_width.setProperty("minimum",0.0)
+
+        # Set Default Options
+        self.form.use_nesting.stateChanged.connect(self.useNestingToggle) 
+
+        self.form.use_nesting.setChecked(False)
+    
+        self.form.use_group_by_size.setChecked(True)
+        
+        # Update the UI
+        self.useNestingToggle()
+        self.UpdateProfileList()
+        self.selectProfilefromSelection()
+        
+
+    def selectProfilefromSelection(self):
+        """ Select the selected Profile if some is used
+        """
+        for selected in FreeCADGui.Selection.getSelection():
+            selLabel = selected.Label
+            found = self.form.profile_list.findItems(selLabel,QtCore.Qt.MatchExactly)
+            if len(found)>0:
+                item = found[0]
+                item.setSelected(True)
+                
+
+
+    def useNestingToggle(self):
+        """ Toggle the Nesting Options depending on the Need
+        """
+        state = self.form.use_nesting.checkState()
+        self.form.max_stock_length.setProperty("enabled",state)
+        self.form.cut_width.setProperty("enabled",state)
+
+    def UpdateProfileList(self):
+        """ Add all Sketches/Profiles/Sections that can be used for the Beam Creation
+        """
+
+        sketches = [s.Label for s in FreeCAD.ActiveDocument.Objects if s.TypeId=="Sketcher::SketchObject"]
+        obj2D = [s.Label for s in FreeCAD.ActiveDocument.Objects if hasattr (s,"Shape") and s.Shape.Faces and not s.Shape.Solids]
+        
+        self.form.profile_list.clear()
+        self.form.profile_list.addItems(sketches)          
+      
+        self.form.profile_list.addItems(obj2D)
+    
+ 
+    def accept(self): 
+        """ Start the Creation of the Cut List
+        """
+        # Get all selected Profiles
+        sel = self.form.profile_list.currentItem()
+        profils = []
+        for item in  self.form.profile_list.selectedItems():
+            profils.append(item.text())
+
+        if profils == []:
+            # Do not try to create a cut list with an empty selection
+            # TODO: Add Message Box
+            return
+        # Get teh Nesting Information or set the default
+        if self.form.use_nesting.checkState() == False:
+            maxStockLength = Units.parseQuantity("0mm")
+            cutWidth = Units.parseQuantity("0mm")
+        else:
+            maxStockLength = self.form.max_stock_length.property('value')
+            cutWidth = self.form.cut_width.property('value')
+        
+        # Generate the Cut List
+        cut_list_creation.createCutlist(profils,
+                                     maxStockLength,
+                                     cutWidth,
+                                     self.form.use_group_by_size.checkState())
+        
+        FreeCADGui.Control.closeDialog()
+    
+    def reject(self):
+        FreeCADGui.Control.closeDialog()
+        
+def openCutListDialog():
+    panel = cutListUI()
+    FreeCADGui.Control.showDialog(panel)

--- a/cut_list/resources/cut_list_dialog.ui
+++ b/cut_list/resources/cut_list_dialog.ui
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>450</width>
+    <height>643</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Create Cut List</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QFrame" name="frame_3">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_4">
+      <item>
+       <widget class="QLabel" name="labelMaxLength_5">
+        <property name="font">
+         <font>
+          <bold>true</bold>
+          <underline>false</underline>
+         </font>
+        </property>
+        <property name="text">
+         <string>Select Profile</string>
+        </property>
+        <property name="margin">
+         <number>10</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QListWidget" name="profile_list">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+          <horstretch>0</horstretch>
+          <verstretch>10</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>150</height>
+         </size>
+        </property>
+        <property name="baseSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="sizeAdjustPolicy">
+         <enum>QAbstractScrollArea::AdjustIgnored</enum>
+        </property>
+        <property name="editTriggers">
+         <set>QAbstractItemView::NoEditTriggers</set>
+        </property>
+        <property name="showDropIndicator" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="alternatingRowColors">
+         <bool>true</bool>
+        </property>
+        <property name="selectionMode">
+         <enum>QAbstractItemView::MultiSelection</enum>
+        </property>
+        <property name="resizeMode">
+         <enum>QListView::Fixed</enum>
+        </property>
+        <property name="layoutMode">
+         <enum>QListView::SinglePass</enum>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="frame_2">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <widget class="QLabel" name="labelMaxLength_4">
+        <property name="font">
+         <font>
+          <bold>true</bold>
+          <underline>false</underline>
+         </font>
+        </property>
+        <property name="text">
+         <string>Cut List Options</string>
+        </property>
+        <property name="margin">
+         <number>10</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="use_group_by_size">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::LeftToRight</enum>
+        </property>
+        <property name="text">
+         <string>Group Parts by Size</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="nesting_option_frame">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="statusTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string/>
+     </property>
+     <property name="accessibleName">
+      <string/>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QLabel" name="labelMaxLength_3">
+        <property name="font">
+         <font>
+          <bold>true</bold>
+          <underline>false</underline>
+         </font>
+        </property>
+        <property name="text">
+         <string>Nesting Options</string>
+        </property>
+        <property name="margin">
+         <number>10</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QFormLayout" name="formLayout">
+        <item row="4" column="0">
+         <widget class="QLabel" name="labelMaxLength_2">
+          <property name="text">
+           <string>Maxmium Stock Length</string>
+          </property>
+          <property name="margin">
+           <number>10</number>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="0">
+         <widget class="QLabel" name="labelCutWidth">
+          <property name="text">
+           <string>Cut Width</string>
+          </property>
+          <property name="margin">
+           <number>10</number>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="Gui::QuantitySpinBox" name="max_stock_length"/>
+        </item>
+        <item row="6" column="1">
+         <widget class="Gui::QuantitySpinBox" name="cut_width"/>
+        </item>
+        <item row="3" column="0">
+         <widget class="QCheckBox" name="use_nesting">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="layoutDirection">
+           <enum>Qt::LeftToRight</enum>
+          </property>
+          <property name="text">
+           <string>Use Nesting</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header location="global">quantityspinbox.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/cut_list/resources/cut_list_icon.svg
+++ b/cut_list/resources/cut_list_icon.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="64mm"
+   height="64mm"
+   viewBox="0 0 64 64"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   sodipodi:docname="cut_list_icon.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="px"
+     inkscape:zoom="1.6211358"
+     inkscape:cx="-44.413306"
+     inkscape:cy="226.69292"
+     inkscape:window-width="1920"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <defs
+     id="defs1">
+    <linearGradient
+       id="swatch4"
+       inkscape:swatch="solid">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4" />
+    </linearGradient>
+    <linearGradient
+       id="swatch2"
+       inkscape:swatch="solid">
+      <stop
+         style="stop-color:#009400;stop-opacity:1;"
+         offset="0"
+         id="stop2" />
+    </linearGradient>
+  </defs>
+  <g
+     fill="currentColor"
+     id="g2"
+     transform="matrix(1.8421124,0,0,1.8421124,-11.947072,-0.55423324)"
+     style="fill:#ffffff;fill-opacity:1;stroke:#ff2121;stroke-opacity:1;fill-rule:evenodd">
+    <path
+       fill="currentColor"
+       d="m 27.087974,16.59918 c 0,0 -1.4,1.3 1.1,2 l -2.8,2.8 h -2.8 c 0,0 -1.9,-0.1 -0.5,2.2 h -4 l -2,-2 c 0,0 -1.3,-1.4 -2,1.1 l -2.8,-2.8 v -2.8 c 0,0 0.1,-1.9 -2.1999998,-0.5 v -4 l 1.9999998,-2 c 0,0 1.4,-1.2999996 -1.1999998,-1.8999996 l 2.7999998,-2.9 h 2.9 c 0,0 1.9,0.1 0.5,-2.2 h 4 l 2,2 c 0,0 1.3,1.4 2,-1.2 l 2.8,2.8 V 10.09918 c 0,0 -0.1,1.9 2.2,0.5 v 4 l -2,2 m -6,-3 a 2,2 0 0 0 -2,-2 2,2 0 0 0 -2,2 2,2 0 0 0 2,2 2,2 0 0 0 2,-2 z"
+       id="path1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#ff2121;stroke-opacity:1;fill-rule:evenodd" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Back" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 2">
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:#020202;stroke-width:0.0887454;stroke-linecap:round;stroke-linejoin:round"
+       id="rect2"
+       width="29.956287"
+       height="38.988598"
+       x="28.50646"
+       y="20.722633" />
+  </g>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:#020202;stroke-width:0.0974015;stroke-linecap:round;stroke-linejoin:round"
+       id="rect3"
+       width="1.0417169"
+       height="0.10363433"
+       x="60.374126"
+       y="30.593719" />
+    <path
+       fill="currentColor"
+       d="M 58.635798,20.848696 V 60.037023 H 27.707069 V 20.848696 Z m -2.577391,2.799167 H 30.28446 V 57.237856 H 56.058407 Z M 35.439243,40.44286 h -2.577392 v -2.799167 h 2.577392 z m 18.041761,0 H 38.016645 v -2.799167 h 15.464359 z m -18.041761,8.397498 h -2.577392 v -2.799166 h 2.577392 z m 18.041761,0 H 38.016645 V 46.041192 H 53.481004 Z M 35.439243,32.045361 h -2.577392 v -2.799166 h 2.577392 z m 18.041761,0 H 38.016645 v -2.799166 h 15.464359 z"
+       id="path2"
+       style="fill:#0056ff;fill-opacity:1;stroke-width:0.0209842" />
+  </g>
+</svg>

--- a/cut_list/resultSpreadsheet.py
+++ b/cut_list/resultSpreadsheet.py
@@ -1,0 +1,176 @@
+# Heavily Inspired Code from 
+# https://github.com/furti/FreeCAD-Reporting/blob/master/report.py
+
+import FreeCAD
+import FreeCADGui
+import string
+
+
+COLUMN_NAMES = list(string.ascii_uppercase)
+
+def literalText(text):
+    return "'%s" % (text)
+
+def lineRange(startColumn, endColumn, lineNumber):
+    return cellRange(startColumn, lineNumber, endColumn, lineNumber)
+
+
+def cellRange(startColumn, startLine, endColumn, endLine):
+    return '%s%s:%s%s' % (startColumn, startLine, endColumn, endLine)
+
+def nextColumnName(actualColumnName):
+    if actualColumnName is None:
+        return COLUMN_NAMES[0]
+
+    nextIndex = COLUMN_NAMES.index(actualColumnName) + 1
+
+    if nextIndex >= len(COLUMN_NAMES):
+        nextIndex -= len(COLUMN_NAMES)
+
+    return COLUMN_NAMES[nextIndex]
+
+
+class ResultSpreadsheet(object):
+
+    def __init__(self, spreadsheet, columnLabels):
+
+        self.spreadsheet = spreadsheet
+        self.lineNumber = 1
+        self.maxColumn = None
+        self.columnLabels = columnLabels
+
+    def getColumnName(self, label):
+        if label is None:
+            return COLUMN_NAMES[0]
+
+        nextIndex = self.columnLabels.index(label)
+
+        if nextIndex >= len(COLUMN_NAMES):
+            nextIndex -= len(COLUMN_NAMES)
+
+        return COLUMN_NAMES[nextIndex]
+
+
+    def clearAll(self):
+        self.spreadsheet.clearAll()
+
+    def printEmptyLine(self):
+        self.lineNumber += 1
+
+    def printHeader(self, header='HAEADER'):
+        spreadsheet = self.spreadsheet
+
+        if header is None or header == '':
+            return
+
+        headerCell = 'A%s' % (self.lineNumber)
+
+        self.setCellValue(headerCell, header)
+        spreadsheet.setStyle(headerCell, 'bold|underline', 'add')
+
+        spreadsheet.mergeCells(lineRange('A', COLUMN_NAMES[len(self.columnLabels)-1], self.lineNumber))
+
+        self.lineNumber += 1
+        self.updateMaxColumn('A')
+
+        self.clearLine(self.lineNumber)
+
+    def printColumnLabels(self):
+        spreadsheet = self.spreadsheet
+
+        columnName = None
+
+        for columnLabel in self.columnLabels:
+            columnName = self.getColumnName(columnLabel)
+            cellName = f"{columnName}{self.lineNumber}"
+            
+            self.setCellValue(cellName, columnLabel)
+
+        spreadsheet.setStyle(
+            lineRange('A', columnName, self.lineNumber), 'bold', 'add')
+
+        self.lineNumber += 1
+        self.updateMaxColumn(columnName)
+
+        self.clearLine(self.lineNumber)
+
+    def printRows(self, rows):
+        lineNumberBefore = self.lineNumber
+
+        columnName = 'A'
+        for row in rows:
+            columnName = None
+
+            for columnlabel, value in row.items():
+                if columnlabel in self.columnLabels:
+                    columnName = self.getColumnName(columnlabel)
+                    cellName = f"{columnName}{self.lineNumber}"
+
+                    self.setCellValue(cellName, value)
+
+            self.lineNumber += 1
+
+        #if printResultInBold:
+        #    self.spreadsheet.setStyle(
+        #        cellRange('A', lineNumberBefore, columnName, self.lineNumber), 'bold', 'add')
+
+        self.clearLine(self.lineNumber)
+
+
+        self.updateMaxColumn(columnName)
+
+    def setCellValue(self, cell, value):
+        if value is None:
+            convertedValue = ''
+        elif isinstance(value, FreeCAD.Units.Quantity):
+            convertedValue = value.UserString
+        else:
+            convertedValue = str(value)
+
+        convertedValue = literalText(convertedValue)
+
+        self.spreadsheet.set(cell, convertedValue)
+
+    def recompute(self):
+        self.spreadsheet.recompute()
+
+    def updateMaxColumn(self, columnName):
+        if self.maxColumn is None:
+            self.maxColumn = columnName
+        else:
+            actualIndex = COLUMN_NAMES.index(self.maxColumn)
+            columnIndex = COLUMN_NAMES.index(columnName)
+
+            if actualIndex < columnIndex:
+                self.maxColumn = columnName
+
+    def clearUnusedCells(self, column, line):
+        if line is not None and line > self.lineNumber:
+            for lineNumberToDelete in range(line, self.lineNumber, -1):
+                self.clearLine(lineNumberToDelete)
+
+        if column is not None:
+            columnIndex = COLUMN_NAMES.index(column)
+            maxColumnIndex = COLUMN_NAMES.index(self.maxColumn)
+
+            if columnIndex > maxColumnIndex:
+                for columnIndexToDelete in range(columnIndex, maxColumnIndex, -1):
+                    self.clearColumn(COLUMN_NAMES[columnIndexToDelete], line)
+
+    def clearLine(self, lineNumberToDelete):
+
+        column = None
+
+        while column is None or column != self.maxColumn:
+            column = nextColumnName(column)
+            cellName = f"{column}{lineNumberToDelete}"
+
+
+            self.spreadsheet.clear(cellName)
+
+    def clearColumn(self, columnToDelete, maxLineNumber):
+
+        for lineNumber in range(1, maxLineNumber):
+            cellName = f"{columnToDelete}{lineNumber + 1}"
+
+            self.spreadsheet.clear(cellName)


### PR DESCRIPTION
Hey,
I use the Dodo Workbench a lot for furniture design and needed a cut list solution for the manufacturing of the beams with little as possible wasted material.

So i created a Function "Create Cut List".

This Function can be used to create a cut list of beams created by the DODO-Workbench.
The cut list can use one or more profiles (sections/sketches).
A position number will be generated for each profile & length combination (rounded to 0.01mm).
The script will create a new spreadsheet object with each cut list.

The Option "Group Parts by Size" will count all Pieces with the same profile and Length (rounded to 0.01mm).

The Option "Use Nesting" allows to specify the maximum length of the Stock Material and allows for optimizing of the available material.
The cut Width will be added to each piece to account for the saw thickness.
The list will be separated into Sections and shows the Used Length and the Parts that can be cut from the Stock Material.
The position number of a piece will be the same on every stock material beam.

Further Information  and a Video can be found in the Forum Post:
https://forum.freecad.org/viewtopic.php?t=85618

Thank you for your Work and Best Regards,
FilePhil
